### PR TITLE
Set up Quakespasm module for automatic update checks

### DIFF
--- a/io.github.lavenderdotpet.LibreQuake.yml
+++ b/io.github.lavenderdotpet.LibreQuake.yml
@@ -19,9 +19,15 @@ modules:
 
   - name: quakespasm
     sources:
-      - type: git
-        url: https://github.com/sezero/quakespasm.git
-        tag: quakespasm-0.96.3
+      - type: archive
+        url: https://api.github.com/repos/sezero/quakespasm/zipball/quakespasm-0.96.3
+        dest-filename: quakespasm.zip
+        sha256: 06a0e48c613388f51d05a0bb51afe027e15db012ec57615d82d5d6bbfd244066
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/sezero/quakespasm/releases/latest
+          version-query: .tag_name
+          url-query: .zipball_url
     no-autogen: true
     no-make-install: true
     subdir: Quake


### PR DESCRIPTION
This is a twofold change:

- move Quakespasm to an `archive` source rather than a `git` source. This is a bit faster to download and work with than a git checkout and will speed up build times a bit.
- Add `x-checker-data` to the Quakespasm module. This will automatically cause the following:
  - on an hourly basis, run a workflow will run on this repository and check the quakespasm module for updates as per the specification
  - if a new release tag is found for Quakespasm, the workflow will create a PR to update the source
  - this PR will automatically start a test build on Flathub's infrastructure that can then be installed
  - once you merge the PR to the `master` branch, the updated Flatpak will be rolled out to Flathub and users will get an update to the LibreQuake flatpak with a new Quakespasm build!