### PR TITLE
Make LibreQuake an `extra-data` source

### DIFF
--- a/io.github.lavenderdotpet.LibreQuake.yml
+++ b/io.github.lavenderdotpet.LibreQuake.yml
@@ -33,42 +33,66 @@ modules:
       - install -D -m755 -t /app/bin/ quakespasm
       - install -D -m644 -t /app/bin/ quakespasm.pak
 
-  - name: librequake-data
-    buildsystem: simple
-    sources:
-      - type: archive
-        url: "https://github.com/lavenderdotpet/LibreQuake/releases/download/v0.08-beta/full.zip"
-        sha256: "b360ff9b2ba3c01da79616fb8d433abe4bbcbe38ec10b8eb71884eba3ac09534"
-    build-commands:
-      - install -d /app/share/librequake
-      - mv id1 /app/share/librequake/
-
-  - name: launch-script
-    sources:
-      - type: script
-        dest-filename: librequake.sh
-        commands:
-          - /app/bin/quakespasm -basedir /app/share/librequake $@
-    buildsystem: simple
-    build-commands:
-      - install -D -m755 -t /app/bin/ librequake.sh
-
   - name: appdata
     buildsystem: simple
     sources:
       - type: file
-        url: https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/35c17070c9dfd2da484a369777cbffeb87a0c4c2/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.svg
+        url: https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/v0.08-beta/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.svg
         sha256: "9ebe794eed8d4a27db3f06ad6002390472c32b31fa6b22ffa945543cf3cca222"
         dest-filename: io.github.lavenderdotpet.LibreQuake.svg
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/lavenderdotpet/LibreQuake/releases/latest
+          version-query: .tag_name
+          url-template: https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/$version/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.svg
       - type: file
-        url: https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/35c17070c9dfd2da484a369777cbffeb87a0c4c2/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.desktop
+        url: https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/v0.08-beta/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.desktop
         sha256: "0e02f35b97dc4a490d3a0055d4e2370739493ce63a001c3467b2f418fa8cb582"
         dest-filename: io.github.lavenderdotpet.LibreQuake.desktop
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/lavenderdotpet/LibreQuake/releases/latest
+          version-query: .tag_name
+          url-template: https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/$version/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.desktop
       - type: file
-        url: https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/35c17070c9dfd2da484a369777cbffeb87a0c4c2/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.metainfo.xml
+        url: https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/v0.08-beta/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.metainfo.xml
         sha256: "065f84f94b58354b2b6e6a913cfbd9cb11bd29894ba27d6780fc05b6210eb5ee"
         dest-filename: io.github.lavenderdotpet.LibreQuake.metainfo.xml
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/lavenderdotpet/LibreQuake/releases/latest
+          version-query: .tag_name
+          url-template: https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/$version/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.metainfo.xml
+      - type: script
+        dest-filename: librequake.sh
+        commands:
+          - /app/bin/quakespasm -basedir /app/extra/librequake $@
     build-commands:
       - install -Dm644 io.github.lavenderdotpet.LibreQuake.svg -t /app/share/icons/hicolor/scalable/apps/
       - install -Dm644 io.github.lavenderdotpet.LibreQuake.desktop -t /app/share/applications/
       - install -Dm644 io.github.lavenderdotpet.LibreQuake.metainfo.xml -t /app/share/metainfo/
+      - install -Dm755 librequake.sh -t /app/bin/
+      - mkdir -p /app/extra/librequake
+
+  - name: librequake-data
+    sources:
+      - type: extra-data
+        filename: librequake.zip
+        url: "https://github.com/lavenderdotpet/LibreQuake/releases/download/v0.08-beta/full.zip"
+        sha256: "b360ff9b2ba3c01da79616fb8d433abe4bbcbe38ec10b8eb71884eba3ac09534"
+        size: 193985987
+        x-checker-data:
+          type: json
+          url: https://api.github.com/repos/lavenderdotpet/LibreQuake/releases/latest
+          version-query: .tag_name
+          url-query: .assets[] | select(.name=="full.zip") | .browser_download_url
+      - type: script
+        dest-filename: apply_extra
+        commands:
+          - mkdir -p /app/extra/librequake
+          - unzip librequake.zip -d lqtmp && rm librequake.zip
+          - mv -v $(find lqtmp -name "id1") /app/extra/librequake/
+          - rm -rf lqtmp
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 apply_extra /app/bin/apply_extra

--- a/io.github.lavenderdotpet.LibreQuake.yml
+++ b/io.github.lavenderdotpet.LibreQuake.yml
@@ -44,7 +44,7 @@ modules:
           type: json
           url: https://api.github.com/repos/lavenderdotpet/LibreQuake/releases/latest
           version-query: .tag_name
-          url-template: https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/$version/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.svg
+          url-query: ("https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/" + .tag_name + "/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.svg")
       - type: file
         url: https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/v0.08-beta/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.desktop
         sha256: "0e02f35b97dc4a490d3a0055d4e2370739493ce63a001c3467b2f418fa8cb582"
@@ -53,7 +53,7 @@ modules:
           type: json
           url: https://api.github.com/repos/lavenderdotpet/LibreQuake/releases/latest
           version-query: .tag_name
-          url-template: https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/$version/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.desktop
+          url-query: ("https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/" + .tag_name + "/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.desktop")
       - type: file
         url: https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/v0.08-beta/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.metainfo.xml
         sha256: "065f84f94b58354b2b6e6a913cfbd9cb11bd29894ba27d6780fc05b6210eb5ee"
@@ -62,7 +62,7 @@ modules:
           type: json
           url: https://api.github.com/repos/lavenderdotpet/LibreQuake/releases/latest
           version-query: .tag_name
-          url-template: https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/$version/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.metainfo.xml
+          url-query: ("https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/" + .tag_name + "/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.metainfo.xml")
       - type: script
         dest-filename: librequake.sh
         commands:

--- a/io.github.lavenderdotpet.LibreQuake.yml
+++ b/io.github.lavenderdotpet.LibreQuake.yml
@@ -61,7 +61,7 @@ modules:
           version-query: .tag_name
           url-query: ("https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/" + .tag_name + "/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.desktop")
       - type: file
-        url: https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/v0.08-beta/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.metainfo.xml
+        url: https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/35c17070c9dfd2da484a369777cbffeb87a0c4c2/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.metainfo.xml
         sha256: "065f84f94b58354b2b6e6a913cfbd9cb11bd29894ba27d6780fc05b6210eb5ee"
         dest-filename: io.github.lavenderdotpet.LibreQuake.metainfo.xml
         x-checker-data:


### PR DESCRIPTION
This will massively reduce the package size hosted by Flathub and speed up build times. `extra-data` sources are not downloaded and installed at build time, but when a user installs the app; the only difference is that they need to go into `/app/extra` rather than anywhere else in the sandbox filesystem.

Additionally, I've added `x-checker-data` to the main LibreQuake data as well as the supplementary files (the desktop shortcut, metainfo file and icon). When a new version of LQ is released, there'll be an automatic pull request updating the sources for all of these to the new version :)