### PR TITLE
Add desktop launcher to open $XDG_DATA_HOME for mods

### DIFF
--- a/io.github.lavenderdotpet.LibreQuake.mods.desktop
+++ b/io.github.lavenderdotpet.LibreQuake.mods.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Categories=Game;ActionGame
+Comment=Directory for LibreQuake mods
+Exec=io.github.lavenderdotpet.LibreQuake.mods.sh
+Icon=io.github.lavenderdotpet.LibreQuake
+Keywords=quake;librequake
+MimeType=
+Name=LibreQuake mod path
+Type=Application
+Terminal=false

--- a/io.github.lavenderdotpet.LibreQuake.yml
+++ b/io.github.lavenderdotpet.LibreQuake.yml
@@ -68,7 +68,15 @@ modules:
         url: https://raw.githubusercontent.com/lavenderdotpet/LibreQuake/35c17070c9dfd2da484a369777cbffeb87a0c4c2/docs/flatpak-metadata/io.github.lavenderdotpet.LibreQuake.metainfo.xml
         sha256: "065f84f94b58354b2b6e6a913cfbd9cb11bd29894ba27d6780fc05b6210eb5ee"
         dest-filename: io.github.lavenderdotpet.LibreQuake.metainfo.xml
+      - type: file
+        path: io.github.lavenderdotpet.LibreQuake.mods.desktop
+      - type: script
+        dest-filename: io.github.lavenderdotpet.LibreQuake.mods.sh
+        commands:
+          - xdg-open $XDG_DATA_HOME
     build-commands:
       - install -Dm644 io.github.lavenderdotpet.LibreQuake.svg -t /app/share/icons/hicolor/scalable/apps/
+      - install -Dm755 io.github.lavenderdotpet.LibreQuake.mods.sh -t /app/bin/
+      - install -Dm644 io.github.lavenderdotpet.LibreQuake.mods.desktop -t /app/share/applications/
       - install -Dm644 io.github.lavenderdotpet.LibreQuake.desktop -t /app/share/applications/
       - install -Dm644 io.github.lavenderdotpet.LibreQuake.metainfo.xml -t /app/share/metainfo/


### PR DESCRIPTION
cc @lavenderdotpet - this will add a second app launcher shortcut to open the LQ Flatpak mod directory! One thing I'm not sure about is how to handle the icon here... I was thinking about maybe adding like a hammer+wrench or gear badge to it but I'm very not certain how to best approach this :thinking: 